### PR TITLE
ci(workflows): use go-version-file instead of hardcoded Go versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version-file: 'go.mod'
   
       - name: coverage
         id: coverage

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,7 +16,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
+
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24'
+          go-version-file: 'go.mod'
+
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24'
+          go-version-file: 'go.mod'
+
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:


### PR DESCRIPTION
- Replace hardcoded Go version strings with go-version-file: 'go.mod'
  in coverage, linter, release, and snapshot workflows
- Ensures CI uses the same Go version as defined in the project

Closes #61